### PR TITLE
Replace a full-width space by a half-with space

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## 64bit Ubuntuの場合
 - libc6-i386
  - 開発ツールの一部が32ビットバイナリのため、32bitバイナリを実行できるようにする必要がある。
- - `sudo apt　install libc6-i386`
+ - `sudo apt install libc6-i386`
 - qemu
  - `sudo apt install qemu`
 - bochs


### PR DESCRIPTION
Copy and paste the command from Readme will result in an error
```
$ sudo apt　install libc6-i386
sudo: apt　install: command not found
```
This PR Fixed it.

自作OS本の環境構築に利用させていただいております。ありがとうございます！
些細なことですが気づいたのでPRいたします。